### PR TITLE
Aligning with changes in jellyfish library

### DIFF
--- a/soft_tfidf.py
+++ b/soft_tfidf.py
@@ -16,7 +16,7 @@ from collections import Counter, namedtuple
 import numpy as np
 import scipy.sparse as sp
 from cachetools import LRUCache
-from jellyfish import jaro_winkler
+from jellyfish import jaro_winkler_similarity
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.preprocessing import normalize
@@ -203,7 +203,7 @@ class SoftTfidf(object):
         y_alt = {}
         for x_ix, s_token in enumerate(x_bag):
             for y_ix, t_token in enumerate(y_bag):
-                dist = jaro_winkler(s_token, t_token)
+                dist = jaro_winkler_similarity(s_token, t_token)
                 if dist >= threshold:
                     sim_pairs.append(self.similar(x_ix, y_ix, dist))
                     x_alt[x_bag[x_ix]] = y_bag[y_ix]
@@ -271,7 +271,7 @@ class SemiSoftTfidf(object):
         idx = self._closest_lexicographic_idx(term)
         windowed_terms = self.sorted_terms[
             max(idx-self.window, self._min_idx): min(idx+self.window, self._max_idx)]
-        return sorted([(jaro_winkler(t, term), t) for t in windowed_terms], reverse=True)
+        return sorted([(jaro_winkler_similarity(t, term), t) for t in windowed_terms], reverse=True)
 
     def _break_tie(self, terms):
         """

--- a/soft_tfidf.py
+++ b/soft_tfidf.py
@@ -16,7 +16,14 @@ from collections import Counter, namedtuple
 import numpy as np
 import scipy.sparse as sp
 from cachetools import LRUCache
-from jellyfish import jaro_winkler_similarity
+#from jellyfish import jaro_winkler_similarity # Slow in new jellyfish implementation
+"""
+Rapidfuzz replacement for jellyfish
+https://github.com/rapidfuzz/JaroWinkler
+pip install jarowinkler
+"""
+from jarowinkler import jarowinkler_similarity as jaro_winkler_similarity # Rapidfuzz efficient replacement for Jellyfish
+
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.preprocessing import normalize


### PR DESCRIPTION
The jellyfish library has undergone significant changes recently, including a switch to a Rust-based implementation for its algorithms. This change has led to performance regressions in certain functions, as reported by users.
Performance Regression: The switch to Rust has caused performance issues in some functions, such as the Hamming distance calculation. Users have reported substantial slowdowns compared to the previous C-based implementation[4](https://github.com/jamesturk/jellyfish/issues/188)
Changes in Function Names: The library has also renamed some functions for consistency. For example, jaro_winkler has been deprecated in favor of jaro_winkler_similarity to match the naming convention of other functions[3](https://jamesturk.github.io/jellyfish/changelog/)

In that context, it is best to switch to Rapidfuzz jarowinkler implemetation.

#from jellyfish import jaro_winkler_similarity # Slow in new jellyfish implementation
"""
Rapidfuzz replacement for jellyfish
https://github.com/rapidfuzz/JaroWinkler
pip install jarowinkler
"""
from jarowinkler import jarowinkler_similarity as jaro_winkler_similarity # Rapidfuzz efficient replacement for Jellyfish